### PR TITLE
Remove dependency on liquibase-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,11 +90,6 @@
             <artifactId>liquibase-core</artifactId>
             <version>${liquibase.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.liquibase</groupId>
-            <artifactId>liquibase-maven-plugin</artifactId>
-            <version>${liquibase.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
This dependency is unused and is adding undesirable things — namely `org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3` and its shaded ASM 5 — to the dependency tree.

@alun @jhaber 